### PR TITLE
Fixes to sending and receiving messages to support vanilla TCP

### DIFF
--- a/draft-brunstrom-taps-impl.md
+++ b/draft-brunstrom-taps-impl.md
@@ -427,7 +427,7 @@ Protocols that provide the framing (such as length-value protocols, or protocols
 
 ### Sending Messages
 
-The effect of the application sending a Message is determined by the top-level protocol in the established Protocol Stack. That is, if the top-level protocol provides an abstraction of framed messages over a connection, the application will be able to send multiple Messages on that connection, even if the framing protocol is built on a byte-stream protocol like TCP.
+The effect of the application sending a Message is determined by the top-level protocol in the established Protocol Stack. That is, if the top-level protocol provides an abstraction of framed messages over a connection, the receiving application will be able to obtain multiple Messages on that connection without supplying a deframer, even if the framing protocol is built on a byte-stream protocol like TCP.
 
 #### Send Parameters
 
@@ -458,7 +458,7 @@ Since sending a Message may involve a context switch between the application and
 
 ### Receiving Messages
 
-Similar to sending, Receiving a Message is determined by the top-level protocol in the established Protocol Stack. The main difference with Receiving is that the size and boundaries of the Message are not known beforehand. The application can communicate in its Receive action the parameters for the Message, which can help the implementation know how much data to deliver and when. For example, if the application only wants to receive a complete Message, the implementation should wait until an entire Message (datagram, stream, or frame) is read before delivering any Message content to the application. Alternatively, the application can specify the minimum number of bytes of Message content it wants to receive (which may be just a single byte) to control the flow of received data.
+Similar to sending, Receiving a Message is determined by the top-level protocol in the established Protocol Stack. The main difference with Receiving is that the size and boundaries of the Message are not known beforehand. The application can communicate in its Receive action the parameters for the Message, which can help the implementation know how much data to deliver and when. For example, if the application only wants to receive a complete Message, the implementation should wait until an entire Message (datagram, stream, or frame) is read before delivering any Message content to the application. This requires the implementation to understand where messages end, either via a supplied deframer or because the top-level protocol in the established Protocol Stack preserves message boundaries; if, on the other hand, the top-level protocol only supports a byte-stream and no deframers were supported, the application must specify the minimum number of bytes of Message content it wants to receive (which may be just a single byte) to control the flow of received data.
 
 If a Connection becomes finished before a requested Receive action can be satisfied, the implementation should deliver any partial Message content outstanding, or if none is available, an indication that there will be no more received Messages.
 
@@ -596,7 +596,7 @@ Connection lifetime for TCP translates fairly simply into the the abstraction pr
 
 If the application sends a Close, that can translate to a graceful termination of the TCP connection, which is performed by sending a FIN to the remote endpoint. If the application sends an Abort, then the TCP state can be closed abruptly, leading to a RST being sent to the peer.
 
-Without a layer of framing above TCP, the cleanest abstraction for sending and receiving Messages over TCP is to treat each direction of the stream of bytes as a single Message, terminated by a FIN. That means that if the application can make several Send calls to enqueue subsequent data chunks for the same Message to continue writing, but marking the Message complete corresponds to closing the sending stream. Similarly, when the application receives the final portion of a Message, it knows that the receiving stream has been closed.
+Without a layer of framing above TCP, the receiver side of the implementation has to rely on a supplied deframer to determine message boundaries. In the absence of such a deframer, a request by the application to only receive complete messages fails.
 
 ## UDP
 

--- a/draft-brunstrom-taps-impl.md
+++ b/draft-brunstrom-taps-impl.md
@@ -427,7 +427,7 @@ Protocols that provide the framing (such as length-value protocols, or protocols
 
 ### Sending Messages
 
-The effect of the application sending a Message is determined by the top-level protocol in the established Protocol Stack. That is, if the top-level protocol provides an abstraction of framed messages over a connection, the receiving application will be able to obtain multiple Messages on that connection without supplying a deframer, even if the framing protocol is built on a byte-stream protocol like TCP.
+The effect of the application sending a Message is determined by the top-level protocol in the established Protocol Stack. That is, if the top-level protocol provides an abstraction of framed messages over a connection, the receiving application will be able to obtain multiple Messages on that connection, even if the framing protocol is built on a byte-stream protocol like TCP.
 
 #### Send Parameters
 
@@ -596,7 +596,7 @@ Connection lifetime for TCP translates fairly simply into the the abstraction pr
 
 If the application sends a Close, that can translate to a graceful termination of the TCP connection, which is performed by sending a FIN to the remote endpoint. If the application sends an Abort, then the TCP state can be closed abruptly, leading to a RST being sent to the peer.
 
-Without a layer of framing above TCP, the receiver side of the implementation has to rely on a supplied deframer to determine message boundaries. In the absence of such a deframer, a request by the application to only receive complete messages fails.
+Without a layer of framing (a top-level protocol in the established Protocol Stack that preserves message boundaries, or an application-supplied deframer) on top of TCP, the receiver side of the transport system implementation can only treat the incoming stream of bytes as a single Message, terminated by a FIN when the Remote Endpoint closes the Connection.
 
 ## UDP
 

--- a/draft-trammell-taps-interface.md
+++ b/draft-trammell-taps-interface.md
@@ -1033,11 +1033,17 @@ conditions holds:
 * the underlying protocol stack does not support message boundary
   preservation, and no deframer was supplied by the application
 
-In this case, the Message object passed to Received may contain an indication
-that the object received is partial, the byte offset of the data in the
-partial Message within the full Message, an indication whether this is the
+The Message object passed to Received will indicate one of the following:
+
+1. this is a complete message;
+2. this is a partial message containing a section of a message with a known message boundary (made partial for local buffering reasons, either by the underlying protocol stack or the deframer). In this case, the Message object passed to Received may contain the byte offset of the data in the partial Message within the full Message, an indication whether this is the
 last (highest-offset) partial Message in the full Message, and an optional
-reference to the full Message it belongs to.
+reference to the full Message it belongs to; or
+3. this is a partial message containing data with no definite message boundary, i.e. the only known message boundary is given by termination of the Connection
+
+Note that in the absence of message boundary preservation and without
+deframing, the entire connection is represented as one large message of
+indeterminate length.
 
 ~~~
 Connection -> ReceiveError<>

--- a/draft-trammell-taps-interface.md
+++ b/draft-trammell-taps-interface.md
@@ -1033,15 +1033,11 @@ conditions holds:
 * the underlying protocol stack does not support message boundary
   preservation, and no deframer was supplied by the application
 
-In this case, the Message object passed to Received contains an indication
+In this case, the Message object passed to Received may contain an indication
 that the object received is partial, the byte offset of the data in the
 partial Message within the full Message, an indication whether this is the
 last (highest-offset) partial Message in the full Message, and an optional
 reference to the full Message it belongs to.
-
-Note that in the degenerate case -- no message boundary preservation and no
-deframing -- the entire connection is represented as one large message of
-indeterminate length.
 
 ~~~
 Connection -> ReceiveError<>


### PR DESCRIPTION
The previous text didn't support sending multiple messages across vanilla TCP without framers/deframers or a top-level protocol in the stack that would de-frame. This change allows sending multiple messages across vanilla TCP and handing them over as bytes to an application that, by itself, detects message boundaries from the chunks of bytes that it gets.