### PR TITLE
Conflicting policies

### DIFF
--- a/draft-brunstrom-taps-impl.md
+++ b/draft-brunstrom-taps-impl.md
@@ -349,6 +349,19 @@ An implementation may use the Capacity Profile to prefer paths optimized for the
 
 \[Note: See {{branch-sorting-non-consensus}} for additional examples related to Properties under discussion.]
 
+If both WiFi and LTE are available, but the application has indicated a preference for WiFi, branches will be sorted accordly, with WiFi at the top. If the application has also indicated a preference for a feature only available in SCTP, branches with SCTP will be sorted to the top within their subtree. However, if the implementation has cached the information that SCTP is not available on the path over WiFi, there is no SCTP node in the WiFi subtree.
+Here, the path over WiFi will be tried first, and, if connection establishment succeeds, TCP will be used. So the path selection property of preferring WiFi takes precedence over the protocol selection property of preferring SCTP.
+
+~~~~~~~~~~
+1. [www.example.com:80, Any, Any Stream]
+  1.1 [192.0.2.1:80, Wi-Fi, Any Stream]
+    1.1.1 [192.0.2.1:80, Wi-Fi, TCP]
+  1.2 [192.0.3.1:80, LTE, Any Stream]
+    1.2.1 [192.0.3.1:80, LTE, SCTP]
+    1.2.2 [192.0.3.1:80, LTE, TCP]
+~~~~~~~~~~
+
+
 ## Candidate Racing
 
 The primary goal of the Candidate Racing process is to successfully negotiate a protocol stack to an endpoint over an interface—to connect a single leaf node of the tree—with as little delay and as few unnecessary connections attempts as possible. Optimizing these two factors improves the user experience, while minimizing network load.

--- a/draft-brunstrom-taps-impl.md
+++ b/draft-brunstrom-taps-impl.md
@@ -328,9 +328,7 @@ Branching for derived endpoints is the final step, and may have multiple layers 
 Implementations should sort the branches of the tree of connection options in order of their preference rank. 
 Leaf nodes on branches with higher rankings represent connection attempts that will be raced first.
 Implementations should order the branches to reflect the preferences expressed by the application for its new connection, including Protocol and Path Selection Properties, which are specified in {{I-D.trammell-taps-interface}}. 
-Path Selection Properties take precedence over Protocol Selection Properties.
 
-If Protocol and Path Selection Properties contain any prohibited properties, the implementation should purge branches containing nodes with these properties.
 In addition to the properties provided by the application, an implementation may include additional criteria such as cached performance estimates, see {{performance-caches}}, or system policy, see {{role-of-system-policy}}, in the ranking.
 Two examples of how the Protocol and Path Selection Properties may be used to sort branches are provided below:
 
@@ -349,8 +347,11 @@ An implementation may use the Capacity Profile to prefer paths optimized for the
 
 \[Note: See {{branch-sorting-non-consensus}} for additional examples related to Properties under discussion.]
 
-If both WiFi and LTE are available, but the application has indicated a preference for WiFi, branches will be sorted accordly, with WiFi at the top. If the application has also indicated a preference for a feature only available in SCTP, branches with SCTP will be sorted to the top within their subtree. However, if the implementation has cached the information that SCTP is not available on the path over WiFi, there is no SCTP node in the WiFi subtree.
-Here, the path over WiFi will be tried first, and, if connection establishment succeeds, TCP will be used. So the path selection property of preferring WiFi takes precedence over the protocol selection property of preferring SCTP.
+Implementations should process properties in the following order: Prohibit, Require, Prefer, Avoid.
+If Protocol or Path Selection Properties contain any prohibited properties, the implementation should first purge branches containing nodes with these properties. For required properties, it should only keep branches that satisfy these requirements. Finally, it should order branches according to preferred properties, and finally use avoided properties as a tiebreaker.
+
+For Require and Avoid, Path Selection Properties take precedence over Protocol Selection Properties.
+For example, if the application has indicated both a preference for WiFi over LTE and for a feature only available in SCTP, branches will be first sorted accord to the Path Selection Property, with WiFi at the top. Then, branches with SCTP will be sorted to the top within their subtree according to the Protocol Selection Property. However, if the implementation has cached the information that SCTP is not available on the path over WiFi, there is no SCTP node in the WiFi subtree. Here, the path over WiFi will be tried first, and, if connection establishment succeeds, TCP will be used. So the Path Selection Property of preferring WiFi takes precedence over the Protocol Selection Property of preferring SCTP.
 
 ~~~~~~~~~~
 1. [www.example.com:80, Any, Any Stream]

--- a/draft-brunstrom-taps-impl.md
+++ b/draft-brunstrom-taps-impl.md
@@ -328,6 +328,9 @@ Branching for derived endpoints is the final step, and may have multiple layers 
 Implementations should sort the branches of the tree of connection options in order of their preference rank. 
 Leaf nodes on branches with higher rankings represent connection attempts that will be raced first.
 Implementations should order the branches to reflect the preferences expressed by the application for its new connection, including Protocol and Path Selection Properties, which are specified in {{I-D.trammell-taps-interface}}. 
+Path Selection Properties take precedence over Protocol Selection Properties.
+
+If Protocol and Path Selection Properties contain any prohibited properties, the implementation should purge branches containing nodes with these properties.
 In addition to the properties provided by the application, an implementation may include additional criteria such as cached performance estimates, see {{performance-caches}}, or system policy, see {{role-of-system-policy}}, in the ranking.
 Two examples of how the Protocol and Path Selection Properties may be used to sort branches are provided below:
 

--- a/draft-trammell-taps-interface.md
+++ b/draft-trammell-taps-interface.md
@@ -361,6 +361,12 @@ transport protocol selection is necessarily tied to path selection. This may
 involve choosing between multiple local interfaces that are connected to
 different access networks.
 
+In case of conflicts between protocol and path selection properties,
+path selection properties take precedence.
+For example, if an application indicates a preference for a specific path, but
+also for a protocol not available on this path, it will get the path it
+prefers, and a protocol that works on this path.
+
 To reflect the needs of an individual Connection, they can be
 specified with five different preference levels:
 

--- a/draft-trammell-taps-interface.md
+++ b/draft-trammell-taps-interface.md
@@ -361,13 +361,6 @@ transport protocol selection is necessarily tied to path selection. This may
 involve choosing between multiple local interfaces that are connected to
 different access networks.
 
-In case of conflicts between protocol and path selection properties,
-path selection properties take precedence.
-For example, if an application indicates a preference for a specific path, but
-also a preference for a protocol not available on this path, the transport
-system will try the path first, so the protocol selection property might not
-have an effect.
-
 To reflect the needs of an individual Connection, they can be
 specified with five different preference levels:
 
@@ -378,6 +371,17 @@ specified with five different preference levels:
    | Ignore     | Cancel any default preference for this property                    |
    | Avoid      | Prefer protocols/paths not providing the property, proceed otherwise |
    | Prohibit   | Select only protocols/paths not providing the property, fail otherwise |
+
+Internally, the transport system will first exclude all protocols and paths
+that match a Prohibit, then only keep candidates that match a Require, then
+sort candidates according to Preferred properties, and then use Avoided
+properties as a tiebreaker.
+In case of conflicts between protocol and path selection properties,
+path selection properties take precedence.
+For example, if an application indicates a preference for a specific path, but
+also a preference for a protocol not available on this path, the transport
+system will try the path first, so the protocol selection property might not
+have an effect.
 
 An implementation of this interface must provide sensible defaults for protocol
 and path selection properties. The defaults given for each property below

--- a/draft-trammell-taps-interface.md
+++ b/draft-trammell-taps-interface.md
@@ -364,8 +364,9 @@ different access networks.
 In case of conflicts between protocol and path selection properties,
 path selection properties take precedence.
 For example, if an application indicates a preference for a specific path, but
-also for a protocol not available on this path, it will get the path it
-prefers, and a protocol that works on this path.
+also a preference for a protocol not available on this path, the transport
+system will try the path first, so the protocol selection property might not
+have an effect.
 
 To reflect the needs of an individual Connection, they can be
 specified with five different preference levels:


### PR DESCRIPTION
Added text about what happens when an application specifies both protocol and path selection properties. Path selection properties have precedence. I added examples to both API and implementation draft to illustrate this. Relates to #149 