### PR TITLE
Prescribe policies for gathering multiple security protocols (or actually, not)

### DIFF
--- a/draft-ietf-taps-arch.md
+++ b/draft-ietf-taps-arch.md
@@ -329,7 +329,18 @@ The Transport System Implementation Concepts define the set of objects used inte
 
 * Path Selection: Path Selection represents the act of choosing one or more paths that are available to use based on the Path Selection Properties provided by the application, and a Transport Services system's policies and heuristics.
 
-* Protocol Selection: Protocol Selection represents the act of choosing one or more sets of protocol options that are available to use based on the Protocol Properties provided by the application, and a Transport Services system's policies and heuristics.
+* Protocol Selection: Protocol Selection represents the act of choosing one or more sets of protocol options that are available to use based on the Protocol Properties provided by the application, and a Transport Services system's policies and heuristics. See {{security-equivalence}} for considerations regarding security Protocol Selection.
+
+#### Security Protocol Gathering and Equivalence {#security-equivalence}
+
+In some cases, Protocol Properties or a Transport Services system's policies and 
+heuristics may yield multiple candidate security protocols. For example, both
+DTLS and TLS may be viable if an application does not express options that
+are prohibited by either UDP or TCP. In such cases, only one security protocol
+SHOULD be used as the outcome of Protocol Selection as deemed appropriate by 
+System Policy. Multiple protocols MAY be used if they are equivalent in terms 
+of configuration and operation. See {{I-D.ietf-taps-transport-security}} for a 
+discussion of criteria that MUST be met for configuration and operation equivalence. 
 
 ### Racing {#racing}
 

--- a/draft-ietf-taps-arch.md
+++ b/draft-ietf-taps-arch.md
@@ -333,14 +333,17 @@ The Transport System Implementation Concepts define the set of objects used inte
 
 #### Security Protocol Gathering and Equivalence {#security-equivalence}
 
-In some cases, Protocol Properties or a Transport Services system's policies and 
-heuristics may yield multiple candidate security protocols. For example, both
-DTLS and TLS may be viable if an application does not express options that
+In some cases, a Transport Services system's policies and heuristics, or individual 
+Protocol Properties, heuristics may yield multiple candidate security protocols. For example, 
+both DTLS and TLS may be viable if an application does not express options that
 are prohibited by either UDP or TCP. In such cases, only one security protocol
 SHOULD be used as the outcome of Protocol Selection as deemed appropriate by 
 System Policy. Multiple protocols MAY be used if they are equivalent in terms 
-of configuration and operation. See {{I-D.ietf-taps-transport-security}} for a 
-discussion of criteria that MUST be met for configuration and operation equivalence. 
+of configuration, operation, and properties. Note that different versions of the same 
+protocol are not necessarily equivalent, even if the underlying cryptographic algorithms 
+are functionally the same. Handshake and wire format differences, among others, prohibit
+equivalence. As an example, TLS 1.2 and TLS 1.3 are NOT equivalent protocols, even if
+configured using the same essential cryptographic algorithms. 
 
 ### Racing {#racing}
 


### PR DESCRIPTION
Addresses #172.

We are limited to only recommending conditions for which multiple security protocols should be offered up. We cannot and should not attempt to define security protocol equivalence. Equivalent algorithms, for example, is not a sufficient condition for equivalence. I give an example of this for TLS 1.2 and 1.3. I think it might behoove us to consider a cross-area document that attempts to define security protocol equivalence to help guide implementations. It's definitely out of scope for these three documents. 