### PR TITLE
Add architecture text for protocol equivalence

### DIFF
--- a/draft-ietf-taps-arch.md
+++ b/draft-ietf-taps-arch.md
@@ -348,7 +348,25 @@ The Transport System Implementation Concepts define the set of objects used inte
 
 * Endpoint Racing: Endpoint Racing is the act of attempting to establish, or scheduling attempts to establish, multiple Protocol Stacks that differ based on the specific representation of the Remote Endpoint and the Local Endpoint, such as IP addresses resolved from a DNS hostname.
 
-### Message Framing, Parsing, and Serialization {#framing}
+## Protocol Stack Equivalence
+
+The Transport Services architecture defines a mechanism that allows applications to easily use different network paths and Protocol Stacks. Transitioning between different Protocol Stacks may in some cases be controlled by properties that only change when application code is updated. For example, an application may enable the use of a multipath or multistreaming transport protocol by modifying the properties in its Pre-Connection configuration. In some cases, however, the Transport Services system will be able to automatically change Protocol Stacks without an update to the application, either by selecting a new stack entirely, or racing multiple candidate Protocol Stacks during connection establishment. This functionality can be a powerful driver of new protocol adoption, but must be constrained carefully to avoid unexpected behavior that can lead to functional or security problems.
+
+If two different Protocol Stacks can be safely swapped, or raced in parallel {{racing}}, then they are considered to be "equivalent". Equivalent Protocol Stacks must meet the following criteria:
+
+1. Both stacks must offer the same interface to the application for connection establishment and data transmission. For example, if one Protocol Stack has UDP as the top-level interface to the application, then it is not equivalent to a Protocol Stack that runs TCP as the top-level interface. Among other differences, the UDP stack would allow an application to read out message boundaries based on datagrams sent from the Remote Endpoint, whereas TCP does not preserve message boundaries on its own.
+
+2. Both stacks must offer the same transport services, as required by the application. For example, if an application specifies that it requires reliable transmission of data, then a Protocol Stack using UDP without any reliability layer on top would not be allowed to replace a Protocol Stack using TCP. However, if the application does not require reliability, then a Protocol Stack that adds unnecessary reliability would be allowed as an equivalent Protocol Stack.
+
+3. Both stacks must offer the same security properties. See the security protocol equivalence section below for futher discussion {{security-equivalence}}.
+
+### Transport Security Equivalence {#security-equivalence}
+
+The inclusion of transport security protocols {{I-D.ietf-taps-transport-security}} in a Protocol Stack adds extra restrictions to Protocol Stack equivalence. Security features, such as encryption, can vary in the level of protection they provide to an application's data depending on which algorithms are used, as well as how the algorithm is used within the protocol. Different protocols or protocol versions that use the same cryptographic algorithms should not be assumed to provide equivalent data protection.
+
+To ensure that security protocols are not incorrectly swapped, Transport Services systems should only automatically generate equivalent Protocol Stacks when the transport security protocols within the stacks are identical. For example, the same version of TLS running over two different transport protocol stacks may be considered equivalent.
+
+## Message Framing, Parsing, and Serialization {#framing}
 
 While some transports expose a byte stream abstraction, most higher level
 protocols impose some structure onto that byte stream. That is, the higher

--- a/draft-ietf-taps-arch.md
+++ b/draft-ietf-taps-arch.md
@@ -352,13 +352,13 @@ The Transport System Implementation Concepts define the set of objects used inte
 
 The Transport Services architecture defines a mechanism that allows applications to easily use different network paths and Protocol Stacks. Transitioning between different Protocol Stacks may in some cases be controlled by properties that only change when application code is updated. For example, an application may enable the use of a multipath or multistreaming transport protocol by modifying the properties in its Pre-Connection configuration. In some cases, however, the Transport Services system will be able to automatically change Protocol Stacks without an update to the application, either by selecting a new stack entirely, or racing multiple candidate Protocol Stacks during connection establishment. This functionality can be a powerful driver of new protocol adoption, but must be constrained carefully to avoid unexpected behavior that can lead to functional or security problems.
 
-If two different Protocol Stacks can be safely swapped, or raced in parallel {{racing}}, then they are considered to be "equivalent". Equivalent Protocol Stacks must meet the following criteria:
+If two different Protocol Stacks can be safely swapped, or raced in parallel (see {{racing}}), then they are considered to be "equivalent". Equivalent Protocol Stacks must meet the following criteria:
 
 1. Both stacks must offer the same interface to the application for connection establishment and data transmission. For example, if one Protocol Stack has UDP as the top-level interface to the application, then it is not equivalent to a Protocol Stack that runs TCP as the top-level interface. Among other differences, the UDP stack would allow an application to read out message boundaries based on datagrams sent from the Remote Endpoint, whereas TCP does not preserve message boundaries on its own.
 
 2. Both stacks must offer the same transport services, as required by the application. For example, if an application specifies that it requires reliable transmission of data, then a Protocol Stack using UDP without any reliability layer on top would not be allowed to replace a Protocol Stack using TCP. However, if the application does not require reliability, then a Protocol Stack that adds unnecessary reliability would be allowed as an equivalent Protocol Stack.
 
-3. Both stacks must offer the same security properties. See the security protocol equivalence section below for futher discussion {{security-equivalence}}.
+3. Both stacks must offer the same security properties. See the security protocol equivalence section below for futher discussion ({{security-equivalence}}).
 
 ### Transport Security Equivalence {#security-equivalence}
 

--- a/draft-ietf-taps-arch.md
+++ b/draft-ietf-taps-arch.md
@@ -356,7 +356,7 @@ If two different Protocol Stacks can be safely swapped, or raced in parallel (se
 
 1. Both stacks must offer the same interface to the application for connection establishment and data transmission. For example, if one Protocol Stack has UDP as the top-level interface to the application, then it is not equivalent to a Protocol Stack that runs TCP as the top-level interface. Among other differences, the UDP stack would allow an application to read out message boundaries based on datagrams sent from the Remote Endpoint, whereas TCP does not preserve message boundaries on its own.
 
-2. Both stacks must offer the same transport services, as required by the application. For example, if an application specifies that it requires reliable transmission of data, then a Protocol Stack using UDP without any reliability layer on top would not be allowed to replace a Protocol Stack using TCP. However, if the application does not require reliability, then a Protocol Stack that adds unnecessary reliability would be allowed as an equivalent Protocol Stack.
+2. Both stacks must offer the same transport services, as required by the application. For example, if an application specifies that it requires reliable transmission of data, then a Protocol Stack using UDP without any reliability layer on top would not be allowed to replace a Protocol Stack using TCP. However, if the application does not require reliability, then a Protocol Stack that adds unnecessary reliability might be allowed as an equivalent Protocol Stack as long as it does not conflict with any other application-requested properties.
 
 3. Both stacks must offer the same security properties. See the security protocol equivalence section below for futher discussion ({{security-equivalence}}).
 

--- a/draft-ietf-taps-arch.md
+++ b/draft-ietf-taps-arch.md
@@ -362,9 +362,9 @@ If two different Protocol Stacks can be safely swapped, or raced in parallel {{r
 
 ### Transport Security Equivalence {#security-equivalence}
 
-The inclusion of transport security protocols {{I-D.ietf-taps-transport-security}} in a Protocol Stack adds extra restrictions to Protocol Stack equivalence. Security features, such as encryption, can vary in the level of protection they provide to an application's data depending on which algorithms are used, as well as how the algorithm is used within the protocol. Different protocols or protocol versions that use the same cryptographic algorithms should not be assumed to provide equivalent data protection.
+The inclusion of transport security protocols {{I-D.ietf-taps-transport-security}} in a Protocol Stack adds extra restrictions to Protocol Stack equivalence. Security features and properties, such as cryptographic algorithms, peer authentication, and identity privacy vary across security protocols, and across versions of security protocols. Protocol equivalence should not be assumed for different protocols or protocol versions, even if they offer similar application configuration options.
 
-To ensure that security protocols are not incorrectly swapped, Transport Services systems should only automatically generate equivalent Protocol Stacks when the transport security protocols within the stacks are identical. For example, the same version of TLS running over two different transport protocol stacks may be considered equivalent.
+To ensure that security protocols are not incorrectly swapped, Transport Services systems should only automatically generate equivalent Protocol Stacks when the transport security protocols within the stacks are identical. Specifically, a system should consider protocols identical only if they are of the same type and version. For example, the same version of TLS running over two different transport protocol stacks may be considered equivalent, whereas TLS 1.2 and TLS 1.3 {{I-D.ietf-tls-tls13}} should not be considered equivalent.
 
 ## Message Framing, Parsing, and Serialization {#framing}
 


### PR DESCRIPTION
Satisfies #172, including text for both generic protocol equivalence and security protocols.

We may want to move the section around organizationally later, as per some of Gorry's comments on structure. However, I reference terms from our concept definitions, so it is easier to write in the latter portion of the document.