### PR TITLE
Rework partial sends and receives

### DIFF
--- a/draft-ietf-taps-interface.md
+++ b/draft-ietf-taps-interface.md
@@ -964,7 +964,7 @@ sending. See {{send-params}} for a description of each parameter.
 messageContext := NewMessage()
 ~~~
 
-The messageData parameter contains any octects to be sent for this message.
+The messageData parameter contains the octects to be sent for this message.
 
 ~~~
 messageData := "hello".octets()

--- a/draft-ietf-taps-interface.md
+++ b/draft-ietf-taps-interface.md
@@ -978,7 +978,7 @@ the available datagram sending size.
 
 If Send is called on a Connection which has not yet been established, an
 Initiate Action will be implicitly performed simultaneously with the Send.
-Used together with the Idempotent property (see {{send-idempotent}}), this can
+Together with the Idempotent property (see {{send-idempotent}}), this can
 be used to send data during establishment for 0-RTT session resumption on
 Protocol Stacks that support it.
 
@@ -1246,7 +1246,7 @@ By default, Receive will try to deliver complete Messages in a single event ({{r
 The application can set a minIncompleteLength value to indicates the smallest partial 
 Message data size in bytes that should be delivered in response to this Receive. By default, 
 this value is infinite, which means that only complete Messages should be delivered. 
-If this value is set to some smaller value, the associated recieve event will be triggered 
+If this value is set to some smaller value, the associated receive event will be triggered 
 only when at least that many bytes are available, or the Message is complete with fewer
 bytes, or the system needs to free up memory. Applications should always
 check the length of the data delivered to the receive event and not assume

--- a/draft-ietf-taps-interface.md
+++ b/draft-ietf-taps-interface.md
@@ -955,7 +955,8 @@ Messages for streaming large data is also supported (see {{send-partial}}).
 
 The most basic form of sending on a connection involves enqueuing a single Data
 block as a complete Message, with default send parameters. Message data is
-created as an array of octets.
+created as an array of octets, and the resulting object contains both the byte
+array and the length of the array.
 
 ~~~
 messageData := "hello".octets()
@@ -1278,6 +1279,9 @@ Connection -> Received<messageData, messageContext>
 A Received event indicates the delivery of a complete Message. It contains two objects,
 the received bytes as messageData, and the metadata and properties of the received
 Message as messageContext. See {#receive-context} for details about the received context.
+
+The messageData object provides access to the bytes that were received for this Message,
+along with the length of the byte array.
 
 See {{receive-framing}} for handling Message framing in situations where the Protocol 
 Stack provides octet-stream transport only.


### PR DESCRIPTION
Satisfies #148 

- Support partial sends more naturally by splitting out into Message, messageData, and endOfMessage flag.
- Do the same for Receive
- Receive should also take minIncompleteLength to specify how partial receives are treated (or not, by default)