### PR TITLE
Moved Connection Properties up to #introspection

### DIFF
--- a/draft-ietf-taps-interface.md
+++ b/draft-ietf-taps-interface.md
@@ -687,7 +687,7 @@ the Connection Group, and so on. Connections in a Connection Group share all
 Protocol Properties that are not applicable to a Message.
 
 Changing one of these Protocol Properties on one Connection in the group changes it for all others. Per-Message Protocol Properties, however, are not entangled.
-For example, changing "Timeout for aborting Connection" (see {{timeout}}) on one Connection in a group will automatically change this Protocol Property for all Connections in the group in the same way. However, changing "Lifetime" (see {{msg-lifetime}}) of a Message will only affect a single Message on a single Connection, entangled or not.
+For example, changing "Timeout for aborting Connection" (see {{conn-timeout}}) on one Connection in a group will automatically change this Protocol Property for all Connections in the group in the same way. However, changing "Lifetime" (see {{msg-lifetime}}) of a Message will only affect a single Message on a single Connection, entangled or not.
 
 If the underlying protocol supports multi-streaming, it is natural to use this functionality to implement Clone. In that case, entangled Connections are multiplexed together, giving them similar treatment not only inside endpoints but also across
 the end-to-end Internet path.
@@ -1791,9 +1791,9 @@ Boolean Connection Property - see {{conn-retrans-notify}}.
 Interger Connection Property - see {{conn-excss-retransmit}}
 
 
-### Notification of ICMP soft error message arrival {#conn-soft-error}
+### Notification of ICMP soft error message arrival
 
-Boolean Connection Property - see {{conn-soft-errorr}}
+Boolean Connection Property - see {{conn-soft-error}}
 
 
 ### Control checksum coverage on sending or receiving {#prop-checksum-control}
@@ -1996,12 +1996,12 @@ Integer Connection Property (read-only) - see {{size-idempotent}}
 Integer Connection Property (read-only) - see {{conn-max-msg-notfrag}}
 
 
-### Maximum Message size on send {#conn-max-msg-send}
+### Maximum Message size on send
 
 Integer Connection Property (read-only) - see {{conn-max-msg-send}}
 
 
-### Maximum Message size on receive {#conn-max-msg-recv}
+### Maximum Message size on receive 
 
 Integer Connection Property (read-only) - see {{conn-max-msg-recv}}
 

--- a/draft-ietf-taps-interface.md
+++ b/draft-ietf-taps-interface.md
@@ -1504,10 +1504,10 @@ does provide the following guarantees about the ordering of operations:
 
 # Transport Properties {#transport-props}
 
-Having discussed Selection Properties in {{connection-props}}, Connection Properties {{connection-props}} and,  Message Properties ({{message-props}}),
+Having discussed Selection Properties in {{selection-props}}, Connection Properties {{connection-props}}, and Message Properties ({{message-props}}),
 we now provide a complete overview of a transport system's defined Transport Properties.
 
-Transport Properties are structured by the context they can apply on: 
+Transport Properties are structured by the phase and object they are applied: 
  - Selection Properties apply to Preconnections - see {{selection-props}}
  - Connections Properties apply to Connections - see {{connection-props}}
  - Messages Properties apply to Messages - see {{message-props}}
@@ -1573,8 +1573,6 @@ When used on a Connection, this type becomes a (read-only) Boolean representing 
 
 ## Transport Property Classification {#transport-props-classes}
 \[TODO: This section is mostly obsolete due to our consensus on how to structure properties -- double-check whether text needs to be moved and delete this section afterwards]
-
-Transport Properties are classified by the the objects that are
 
 
 ### Selection Properties {#selection-props}
@@ -1788,7 +1786,7 @@ Boolean Connection Property - see {{conn-retrans-notify}}.
 
 ### Retransmission threshold before excessive retransmission notification
 
-Interger Connection Property - see {{conn-excss-retransmit}}
+Integer Connection Property - see {{conn-excss-retransmit}}
 
 
 ### Notification of ICMP soft error message arrival


### PR DESCRIPTION
This is the second step towards applying our new Properties
Classification. It moves up the Connection Properties and annotates most
places with stuff to do.