### PR TITLE
clean up capacity profile per #142

### DIFF
--- a/draft-ietf-taps-interface.md
+++ b/draft-ietf-taps-interface.md
@@ -1922,49 +1922,50 @@ values are valid for the Capacity Profile:
   Default: : The application makes no representation about its expected capacity
   profile. No special optimizations of the tradeoff between delay, delay
   variation, and bandwidth efficiency should be made when selecting and
-  configuring transport protocol stacks. When the underlying transport protocol
-  stack(s) support per-connection DSCP signaling, transmitted traffic SHOULD
-  carry the DSCP Default Forwarding {{?RFC2474}} PHB; when the Connection is
-  multiplexed, the guidelines in section 6 of {{?RFC7657}} apply.
+  configuring transport protocol stacks. Transport system implementations that
+  map the requested capacity profile onto per-connection DSCP signaling without
+  multiplexing SHOULD assign the DSCP Default Forwarding {{?RFC2474}} PHB; when
+  the Connection is multiplexed, the guidelines in section 6 of {{?RFC7657}}
+  apply.
 
   Scavenger/Bulk: : The application is not interactive. It expects to send
   and/or receive data without any urgency. This can, for example, be used to
   select protocol stacks with scavenger transmission control and/or to assign
-  the traffic to a lower-effort service. When the underlying transport protocol
-  stack(s) support per-connection DSCP signaling, transmitted traffic SHOULD
-  carry the DSCP Less than Best Effort {{?LE-PHB=I-D.ietf-tsvwg-le-phb}} PHB;
-  when the Connection is multiplexed, the guidelines in section 6 of
-  {{?RFC7657}} apply.
+  the traffic to a lower-effort service. Transport system implementations that
+  map the requested capacity profile onto per-connection DSCP signaling without
+  multiplexing SHOULD assign the DSCP Less than Best Effort
+  {{?LE-PHB=I-D.ietf-tsvwg-le-phb}} PHB; when the Connection is multiplexed, the
+  guidelines in section 6 of {{?RFC7657}} apply.
 
   Low Latency/Interactive: : The application is interactive, and prefers loss to
   latency. Response time should be optimized at the expense of bandwidth
   efficiency and delay variation when sending on this connection. This can be
   used by the system to disable the coalescing of multiple small Messages into
   larger packets (Nagle's algorithm); to prefer immediate acknowledgment from
-  the peer endpoint when supported by the underlying transport; and so on. When
-  the underlying transport protocol stack(s) support per-connection DSCP
-  signaling, transmitted traffic SHOULD carry the DSCP Expedited Forwarding
-  {{?RFC3246}} PHB; when the Connection is multiplexed, the guidelines in
-  section 6 of {{?RFC7657}} apply.
+  the peer endpoint when supported by the underlying transport; and so on.
+  Transport system implementations that map the requested capacity profile onto
+  per-connection DSCP signaling without multiplexing SHOULD assign the DSCP
+  Expedited Forwarding {{?RFC3246}} PHB; when the Connection is multiplexed, the
+  guidelines in section 6 of {{?RFC7657}} apply.
 
   Low Latency/Non-Interactive: : The application prefers loss to latency but is
   not interactive. Response time should be optimized at the expense of bandwidth
-  efficiency and delay variation when sending on this connection. When the
-  underlying transport protocol stack(s) support per-connection DSCP signaling,
-  transmitted traffic SHOULD carry a DSCP Assured Forwarding
-  (AF21,AF22,AF23,AF24) {{?RFC2597}} PHB; when the Connection is multiplexed,
-  the guidelines in section 6 of {{?RFC7657}} apply.
+  efficiency and delay variation when sending on this connection.Transport
+  system implementations that map the requested capacity profile onto
+  per-connection DSCP signaling without multiplexing SHOULD assign a DSCP
+  Assured Forwarding (AF21,AF22,AF23,AF24) {{?RFC2597}} PHB; when the Connection
+  is multiplexed, the guidelines in section 6 of {{?RFC7657}} apply.
 
   Constant-Rate Streaming: : The application expects to send/receive data at a
   constant rate after Connection establishment. Delay and delay variation should
   be minimized at the expense of bandwidth efficiency. This implies that the
   Connection may fail if the desired rate cannot be maintained across the Path.
   A transport may interpret this capacity profile as preferring a circuit
-  breaker {{?RFC8084}} to a rate-adaptive congestion controller. When the
-  underlying transport protocol stack(s) support per-connection DSCP signaling,
-  transmitted traffic SHOULD carry a DSCP Assured Forwarding
-  (AF31,AF32,AF33,AF34) {{?RFC2597}} PHB; when the Connection is multiplexed,
-  the guidelines in section 6 of {{?RFC7657}} apply.
+  breaker {{?RFC8084}} to a rate-adaptive congestion controller. Transport
+  system implementations that map the requested capacity profile onto
+  per-connection DSCP signaling without multiplexing SHOULD assign a DSCP
+  Assured Forwarding (AF31,AF32,AF33,AF34) {{?RFC2597}} PHB; when the Connection
+  is multiplexed, the guidelines in section 6 of {{?RFC7657}} apply.
 
   High Throughput Data: : \[EDITOR'S NOTE: Gorry wants this, but bht has no idea
   how to implement it beyond DSCP AF1n {{?RFC2597}}. Cut, or specity how this is

--- a/draft-ietf-taps-interface.md
+++ b/draft-ietf-taps-interface.md
@@ -1928,7 +1928,7 @@ values are valid for the Capacity Profile:
   the Connection is multiplexed, the guidelines in section 6 of {{?RFC7657}}
   apply.
 
-  Scavenger/Bulk: : The application is not interactive. It expects to send
+  Scavenger: : The application is not interactive. It expects to send
   and/or receive data without any urgency. This can, for example, be used to
   select protocol stacks with scavenger transmission control and/or to assign
   the traffic to a lower-effort service. Transport system implementations that

--- a/draft-ietf-taps-interface.md
+++ b/draft-ietf-taps-interface.md
@@ -1967,9 +1967,14 @@ values are valid for the Capacity Profile:
   Assured Forwarding (AF31,AF32,AF33,AF34) {{?RFC2597}} PHB; when the Connection
   is multiplexed, the guidelines in section 6 of {{?RFC7657}} apply.
 
-  High Throughput Data: : \[EDITOR'S NOTE: Gorry wants this, but bht has no idea
-  how to implement it beyond DSCP AF1n {{?RFC2597}}. Cut, or specity how this is
-  really different from one of the other profiles.]
+  High Throughput Data: : The application expects to send/receive data at the
+  maximum rate allowed by its congestion controller over a relatively long
+  period of time. Transport system implementations that map the requested
+  capacity profile onto per-connection DSCP signaling without multiplexing
+  SHOULD assign a DSCP Assured Forwarding (AF11,AF12,AF13,AF14) {{?RFC2597}} PHB
+  per section 4.8 of {{?RFC4594}}. When the Connection is multiplexed, the
+  guidelines in section 6 of {{?RFC7657}} apply.
+
 
 ### Congestion control {#prop-cc}
 

--- a/draft-ietf-taps-interface.md
+++ b/draft-ietf-taps-interface.md
@@ -1912,29 +1912,29 @@ Type:
 Applicability:
 : Preconnection, Connection, Message
 
-This property specifies the traffic interaction pattern expected by the
-application, the desired network treatment for traffic sent by the application,
-and the tradeoffs the application is prepared to make in path and protocol
-selection to receive that desired treatment. When the capacity profile is set to
-a value other than Default, the transport system should select paths and
-profiles to optimize for the capacity profile specified. The following values
-are valid for the Capacity Profile:
+This property specifies the desired network treatment for traffic sent by the
+application and the tradeoffs the application is prepared to make in path and
+protocol selection to receive that desired treatment. When the capacity profile
+is set to a value other than Default, the transport system should select paths
+and profiles to optimize for the capacity profile specified. The following
+values are valid for the Capacity Profile:
 
-  Default:
-  : The application makes no representation about its expected capacity
+  Default: : The application makes no representation about its expected capacity
   profile. No special optimizations of the tradeoff between delay, delay
   variation, and bandwidth efficiency should be made when selecting and
   configuring transport protocol stacks. When the underlying transport protocol
-  stack(s) support per-connection DSCP signaling, transmitted traffic SHOULD carry
-  the DSCP Best Effort PHB. \[EDITOR'S NOTE: cite]
+  stack(s) support per-connection DSCP signaling, transmitted traffic SHOULD
+  carry the DSCP Default Forwarding {{?RFC2474}} PHB; when the Connection is
+  multiplexed, the guidelines in section 6 of {{?RFC7657}} apply.
 
-  Scavenger/Bulk: 
-  : The application is not interactive. It expects to send
-  and/or receive a large amount of data, without any urgency. This can, for
-  example, be used to select protocol stacks with scavenger transmission control
-  and/or to assign the traffic to a lower-effort service. When the underlying
-  transport protocol stack(s) support per-connection DSCP signaling, transmitted
-  traffic SHOULD carry the DSCP Less than Best Effort PHB. \[EDITOR'S NOTE: cite]
+  Scavenger/Bulk: : The application is not interactive. It expects to send
+  and/or receive data without any urgency. This can, for example, be used to
+  select protocol stacks with scavenger transmission control and/or to assign
+  the traffic to a lower-effort service. When the underlying transport protocol
+  stack(s) support per-connection DSCP signaling, transmitted traffic SHOULD
+  carry the DSCP Less than Best Effort {{?LE-PHB=I-D.ietf-tsvwg-le-phb}} PHB;
+  when the Connection is multiplexed, the guidelines in section 6 of
+  {{?RFC7657}} apply.
 
   Low Latency/Interactive: : The application is interactive, and prefers loss to
   latency. Response time should be optimized at the expense of bandwidth
@@ -1943,19 +1943,19 @@ are valid for the Capacity Profile:
   larger packets (Nagle's algorithm); to prefer immediate acknowledgment from
   the peer endpoint when supported by the underlying transport; and so on. When
   the underlying transport protocol stack(s) support per-connection DSCP
-  signaling, transmitted traffic SHOULD carry the DSCP Expedited Forwarding PHB.
-  \[EDITOR'S NOTE: cite]
+  signaling, transmitted traffic SHOULD carry the DSCP Expedited Forwarding
+  {{?RFC3246}} PHB; when the Connection is multiplexed, the guidelines in
+  section 6 of {{?RFC7657}} apply.
 
-  Low Latency/Non-Interactive: 
-  : The application prefers loss to latency but is
+  Low Latency/Non-Interactive: : The application prefers loss to latency but is
   not interactive. Response time should be optimized at the expense of bandwidth
   efficiency and delay variation when sending on this connection. When the
   underlying transport protocol stack(s) support per-connection DSCP signaling,
   transmitted traffic SHOULD carry a DSCP Assured Forwarding
-  (AF21,AF22,AF23,AF24) PHB. \[EDITOR'S NOTE: cite]
+  (AF21,AF22,AF23,AF24) {{?RFC2597}} PHB; when the Connection is multiplexed,
+  the guidelines in section 6 of {{?RFC7657}} apply.
 
-  Constant-Rate Streaming: 
-  : The application expects to send/receive data at a
+  Constant-Rate Streaming: : The application expects to send/receive data at a
   constant rate after Connection establishment. Delay and delay variation should
   be minimized at the expense of bandwidth efficiency. This implies that the
   Connection may fail if the desired rate cannot be maintained across the Path.
@@ -1963,11 +1963,12 @@ are valid for the Capacity Profile:
   breaker {{?RFC8084}} to a rate-adaptive congestion controller. When the
   underlying transport protocol stack(s) support per-connection DSCP signaling,
   transmitted traffic SHOULD carry a DSCP Assured Forwarding
-  (AF31,AF32,AF33,AF34) PHB.
+  (AF31,AF32,AF33,AF34) {{?RFC2597}} PHB; when the Connection is multiplexed,
+  the guidelines in section 6 of {{?RFC7657}} apply.
 
   High Throughput Data: : \[EDITOR'S NOTE: Gorry wants this, but bht has no idea
-  how to implement it beyond DSCP AF2n. Cut, or specity how this is really
-  different from one of the other profiles.]
+  how to implement it beyond DSCP AF1n {{?RFC2597}}. Cut, or specity how this is
+  really different from one of the other profiles.]
 
 ### Congestion control {#prop-cc}
 

--- a/draft-ietf-taps-interface.md
+++ b/draft-ietf-taps-interface.md
@@ -1904,7 +1904,7 @@ options.
 ### Capacity Profile {#prop-cap-profile}
 
 Classification:
-: Intent \[TODO: Discuss]
+: Selection Property
 
 Type:
 : Enumeration
@@ -1912,39 +1912,62 @@ Type:
 Applicability:
 : Preconnection, Connection, Message
 
-This property specifies the application's expectation of the dominating traffic pattern for this Connection.
-This implies that the transport system should optimize for the capacity profile specified. This can influence path and protocol selection.
-The following values are valid for the Capacity Profile:
+This property specifies the traffic interaction pattern expected by the
+application, the desired network treatment for traffic sent by the application,
+and the tradeoffs the application is prepared to make in path and protocol
+selection to receive that desired treatment. When the capacity profile is set to
+a value other than Default, the transport system should select paths and
+profiles to optimize for the capacity profile specified. The following values
+are valid for the Capacity Profile:
 
   Default:
-  : The application makes no request about its expected
-  capacity profile. No special optimizations of the tradeoff between
-  delay, delay variation, and bandwidth efficiency should be made when selecting and
-  configuring stacks.
+  : The application makes no representation about its expected capacity
+  profile. No special optimizations of the tradeoff between delay, delay
+  variation, and bandwidth efficiency should be made when selecting and
+  configuring transport protocol stacks. When the underlying transport protocol
+  stack(s) support per-connection DSCP signaling, transmitted traffic SHOULD carry
+  the DSCP Best Effort PHB. \[EDITOR'S NOTE: cite]
 
-  Low Latency:
-  : Response time (latency) should be optimized at
-  the expense of bandwidth efficiency and delay variation when sending this
-  message. This can be used by the system to disable the coalescing of
-  multiple small Messages into larger packets (Nagle's algorithm); to prefer
-  immediate acknowledgment from the peer endpoint when supported by the
-  underlying transport; to signal a preference for lower-latency, higher-loss
-  treatment; and so on.
+  Scavenger/Bulk: 
+  : The application is not interactive. It expects to send
+  and/or receive a large amount of data, without any urgency. This can, for
+  example, be used to select protocol stacks with scavenger transmission control
+  and/or to assign the traffic to a lower-effort service. When the underlying
+  transport protocol stack(s) support per-connection DSCP signaling, transmitted
+  traffic SHOULD carry the DSCP Less than Best Effort PHB. \[EDITOR'S NOTE: cite]
 
-  Constant Rate:
-  : The application expects to send/receive data at a constant rate after
-  Connection establishment. Delay and delay variation should be minimized at the
-  expense of bandwidth efficiency. This implies that the Connection may fail
-  if the desired rate cannot be maintained across the Path. A transport
-  may interpret this capacity profile as preferring a circuit breaker
-  {{?RFC8084}} to a rate-adaptive congestion controller.
+  Low Latency/Interactive: : The application is interactive, and prefers loss to
+  latency. Response time should be optimized at the expense of bandwidth
+  efficiency and delay variation when sending on this connection. This can be
+  used by the system to disable the coalescing of multiple small Messages into
+  larger packets (Nagle's algorithm); to prefer immediate acknowledgment from
+  the peer endpoint when supported by the underlying transport; and so on. When
+  the underlying transport protocol stack(s) support per-connection DSCP
+  signaling, transmitted traffic SHOULD carry the DSCP Expedited Forwarding PHB.
+  \[EDITOR'S NOTE: cite]
 
-  Scavenger/Bulk:
-  : The application is not interactive. It expects to send/receive a large
-  amount of data, without any urgency. This can, for example, be used to select protocol
-  stacks with scavenger transmission control, to signal a preference for
-  less-than-best-effort treatment, or to assign the traffic to a lower-effort service.
+  Low Latency/Non-Interactive: 
+  : The application prefers loss to latency but is
+  not interactive. Response time should be optimized at the expense of bandwidth
+  efficiency and delay variation when sending on this connection. When the
+  underlying transport protocol stack(s) support per-connection DSCP signaling,
+  transmitted traffic SHOULD carry a DSCP Assured Forwarding
+  (AF21,AF22,AF23,AF24) PHB. \[EDITOR'S NOTE: cite]
 
+  Constant-Rate Streaming: 
+  : The application expects to send/receive data at a
+  constant rate after Connection establishment. Delay and delay variation should
+  be minimized at the expense of bandwidth efficiency. This implies that the
+  Connection may fail if the desired rate cannot be maintained across the Path.
+  A transport may interpret this capacity profile as preferring a circuit
+  breaker {{?RFC8084}} to a rate-adaptive congestion controller. When the
+  underlying transport protocol stack(s) support per-connection DSCP signaling,
+  transmitted traffic SHOULD carry a DSCP Assured Forwarding
+  (AF31,AF32,AF33,AF34) PHB.
+
+  High Throughput Data: : \[EDITOR'S NOTE: Gorry wants this, but bht has no idea
+  how to implement it beyond DSCP AF2n. Cut, or specity how this is really
+  different from one of the other profiles.]
 
 ### Congestion control {#prop-cc}
 


### PR DESCRIPTION
This is a (work in progress) attempt to clean up Capacity Profile as a selection property along the lines of the state of the discussion in #142.

@gorryfair: you had a suggestion to add "High Throughput Data" as a separate profile mapping to AF2n, but I don't know anything else about what this would actually imply for transport selection; can you help me out here?