### PR TITLE
small wording edit on event driven API

### DIFF
--- a/draft-ietf-taps-arch.md
+++ b/draft-ietf-taps-arch.md
@@ -158,7 +158,7 @@ There are a few key departures that Transport Services makes from the sockets AP
 
 ## Event-Driven API
 
-Originally, sockets presented a blocking interface for establishing connections and transferring data. However, most modern applications interact with the network asynchronously. When sockets are presented as an asynchronous interface, they generally use a try-and-fail model. If the application wants to read, but data has not yet been received from the peer, the call to read will fail. The application then waits for a notification that it should try again.
+Originally, sockets presented a blocking interface for establishing connections and transferring data. However, most modern applications interact with the network asynchronously. When sockets are presented as an asynchronous interface, they generally use a try-and-fail model. If the application wants to read, but data has not yet been received from the peer, the call to read will fail. The application then waits and some times later tries again.
 
 All interaction with a Transport Services system is expected to be asynchronous, and use an event-driven model unlike sockets {{events}}. For example, if the application wants to read, its call to read will not fail, but will deliver an event containing the received data once it is available.
 


### PR DESCRIPTION
I guess here is not nessecarily a notification required in sychronuous communication