### PR TITLE
Last missing bits from minset. Closes #109. Closes #246.

### DIFF
--- a/draft-ietf-taps-interface.md
+++ b/draft-ietf-taps-interface.md
@@ -616,6 +616,17 @@ particular instance. While this does restrict path selection, it is broader than
 requiring specific PvD instances or interface instances, and should be preferred
 over these options.
 
+### Parallel Use of Multiple Paths
+
+This property specifies whether an application considers it useful to
+transfer data across multiple paths between the same end hosts. Generally,
+in most cases, this will improve performance (e.g., achieve greater throughput).
+One possible side-effect is increased jitter, which may be problematic for
+delay-sensitive applications.
+
+The recommended default is to have this option.
+
+
 ### Direction of communication
 
 This property specifies whether an application wants to use the connection for sending and/or receiving data.  Possible values are:
@@ -1758,20 +1769,6 @@ This property specifies an upper-bound rate that a transfer is not expected to
 exceed (even if flow control and congestion control allow higher rates), and/or a
 lower-bound rate below which the application does not deem
 a data transfer useful. It is given in bits per second.
-
-
-### Parallel Use of Multiple Paths
-
-Type:
-: Boolean
-
-This property specifies whether an application considers it useful to
-transfer data across multiple paths between the same end hosts. Generally,
-in most cases, this will improve performance (e.g., achieve greater throughput).
-One possible side-effect is increased jitter, which may be problematic for
-delay-sensitive applications.
-
-The recommended default is to have this option.
 
 
 ### TCP-specific Property: User Timeout

--- a/draft-ietf-taps-interface.md
+++ b/draft-ietf-taps-interface.md
@@ -1841,7 +1841,7 @@ Abort terminates a Connection without delivering remaining data:
 Connection.Abort()
 ~~~
 
-A ConnectionError informs the application that data to could not be delivered for too long
+A ConnectionError informs the application that data to could not be delivered after a timeout, 
 or the other side has aborted the Connection; however, there is no guarantee that an Abort will indeed be signaled.
 
 ~~~

--- a/draft-ietf-taps-interface.md
+++ b/draft-ietf-taps-interface.md
@@ -635,11 +635,8 @@ the system should fall back to bidirectional transport.
 
 ### Timeout for aborting Connection Establishment {#conn-establish-timeout}
 
-Type:
-: Integer
-
 This property specifies how long to wait before aborting a Connection during establishment.
-It is given in seconds.
+
 
 
 ## Specifying Security Parameters and Callbacks {#security-parameters}
@@ -1634,11 +1631,8 @@ are cloned.
 
 ### Timeout for aborting Connection {#conn-timeout}
 
-Type:
-: Integer
-
 This property specifies how long to wait before deciding that a Connection has
-failed after establishment. It is given in seconds.
+failed after establishment.
 
 ### Connection group transmission scheduler {#conn-scheduler}
 
@@ -2006,7 +2000,7 @@ definition.
 "Listen" Action.
 
 * Specify number of attempts and/or timeout for the first establishment message:  
-"Timeout for aborting Connection Establishment" Property, using a time value in seconds.
+"Timeout for aborting Connection Establishment" Property, using a time value.
 
 * Disable MPTCP:  
 "Parallel Use of Multiple Paths" Property.
@@ -2018,7 +2012,7 @@ definition.
 "InitiateWithSend" Action.
 
 * Change timeout for aborting connection (using retransmit limit or time value):  
-"Timeout for aborting Connection" property, using a time value in seconds.
+"Timeout for aborting Connection" property, using a time value.
 
 * Timeout event when data could not be delivered for too long:  
 "ConnectionError" Event.


### PR DESCRIPTION
Notable changes:
- added control over using multipath (which was a late addition to minset)
- added a timeout for conn. establishment, separate from the other conn. abort timeout (see #109)
- renamed InitiateWithIdempotentSend into InitiateWithSend, and adjusted the text to recommend declaring idempotence. This addresses the minset function that goes back to TCP's send-with-SYN.