### PR TITLE
Define a IANA registry for Transport Property Names

### DIFF
--- a/draft-ietf-taps-interface.md
+++ b/draft-ietf-taps-interface.md
@@ -281,14 +281,18 @@ stages:
  - Message Properties can be set on Preconnections and Connections
  - The effect of Selection Properties can be queried on Connections and Messages
 
-The Transport Properties Names are hierarchically organized in the form
+The Transport Properties Names are CamelCased strings.
+They are hierarchically organized in the form
 \[\<domain\>.\]\<PropertyName\>. The Domain part is empty for well known, generic properties, i.e., for properties defined by an RFC which use is not limited to a specific protocol. Otherwise, the domain part specifies the domain they apply to --- see {{iana}} for the assignment policy and initial values.
+All Transport Properties specified in this document are well known, generic properties.
 
 Transport Properties can have one of a set of data types:
 
 - Boolean: can take the values "true" and "false"; representation is
   implementation-dependent.
-- Integer: can take positive or negative numeric values; range and
+- Integer: can take positive or negative numeric integer values; range and
+  representation is implementation-dependent.
+- Numeric: can take positive or negative numeric values; range and
   representation is implementation-dependent.
 - Enumeration: can take one value of a finite set of values, dependent on the
   property itself. The representation is implementation dependent; however,
@@ -1093,7 +1097,7 @@ The following Message Properties are supported:
 ### Lifetime {#msg-lifetime}
 
 Type:
-: Integer
+: Numeric
 
 Lifetime specifies how long a particular Message can wait to be sent to the
 remote endpoint before it is irrelevant and no longer needs to be
@@ -1649,6 +1653,9 @@ are cloned.
 
 ### Timeout for aborting Connection {#conn-timeout}
 
+Type:
+: Numeric
+
 This property specifies how long to wait before deciding that a Connection has
 failed after establishment.
 
@@ -1771,6 +1778,9 @@ per-Message basis using the Transmission Profile Message Property; see
 
 
 ### Bounds on Send or Receive Rate
+
+Type:
+: Numeric
 
 This property specifies an upper-bound rate that a transfer is not expected to
 exceed (even if flow control and congestion control allow higher rates), and/or a

--- a/draft-ietf-taps-interface.md
+++ b/draft-ietf-taps-interface.md
@@ -257,7 +257,7 @@ Errors and other notifications also happen asynchronously on the Connection.
 through Actions and Events in each phase of a Connection, following the phases
 described in {{I-D.ietf-taps-arch}}.
 
-## Transport Properties
+## Transport Properties {#transport-properties}
 
 Each application using the Transport Services Interface declares its preferences
 for how the transport service should operate using properties at each stage of
@@ -280,6 +280,9 @@ stages:
  - Connection Properties can be set on Preconnections
  - Message Properties can be set on Preconnections and Connections
  - The effect of Selection Properties can be queried on Connections and Messages
+
+The Transport Properties Names are hierarchically organized in the form
+\[\<domain\>.\]\<PropertyName\>. The Domain part is empty for well known, generic properties, i.e., for properties defined by an RFC which use is not limited to a specific protocol. Otherwise, the domain part specifies the domain they apply to --- see {{iana}} for the assignment policy and initial values.
 
 Transport Properties can have one of a set of data types:
 
@@ -1890,11 +1893,14 @@ The interface provides the following guarantees about the ordering of
   where application ignores these errors.
 
 
-# IANA Considerations
+# IANA Considerations {#iana}
 
-RFC-EDITOR: Please remove this section before publication.
+This document creates a new registry group entitled "TAPS Transport Properties" with two registries: "Transport Property Domains" and "Well-Known Generic Transport Properties". Their use is described in {{transport-properties}}.
 
-This document has no Actions for IANA.
+## Transport Property Domains {#property-domains}
+
+## Well-Known Generic Transport Properties {#generic-properties}
+
 
 # Security Considerations
 

--- a/draft-ietf-taps-interface.md
+++ b/draft-ietf-taps-interface.md
@@ -283,7 +283,11 @@ stages:
 
 The Transport Properties Names are CamelCased strings.
 They are hierarchically organized in the form
-\[\<domain\>.\]\<PropertyName\>. The Domain part is empty for well known, generic properties, i.e., for properties defined by an RFC which use is not limited to a specific protocol. Otherwise, the domain part specifies the domain they apply to --- see {{iana}} for the assignment policy and initial values.
+\[\<domain\>.\]\<PropertyName\>. 
+The Domain part is empty for well known, generic properties, i.e., properties 
+defined by an RFC which use is not limited to a specific protocol. Otherwise, 
+the domain part specifies the domain they apply to, e.g., a specific protocol, vendor, or implementation.
+See {{iana}} for the assignment policy and an overview of the initial values.
 All Transport Properties specified in this document are well known, generic properties.
 
 Transport Properties can have one of a set of data types:
@@ -1788,7 +1792,7 @@ lower-bound rate below which the application does not deem
 a data transfer useful. It is given in bits per second.
 
 
-### TCP-specific Property: User Timeout
+### TCP-specific Property: User Timeout 
 
 This property specifies, for the case TCP becomes the chosen transport protocol:
 
@@ -1905,11 +1909,48 @@ The interface provides the following guarantees about the ordering of
 
 # IANA Considerations {#iana}
 
-This document creates a new registry group entitled "TAPS Transport Properties" with two registries: "Transport Property Domains" and "Well-Known Generic Transport Properties". Their use is described in {{transport-properties}}.
+This document creates a new registry group entitled "TAPS Transport Properties" to hold the definition of Transport Property names as described in {{transport-properties}}.
 
 ## Transport Property Domains {#property-domains}
 
-## Well-Known Generic Transport Properties {#generic-properties}
+This registry contains the names used in the the domain part of Transport Property names. 
+These are used to delegate the definitions of protocol, implementation, or 
+vendor specific Transport Properties to the respective sub-registries or 
+documents. The names are Protocol Acronyms or CamelCased strings, The reference field must point to the document defining the namespace and assignment policy.
+
+Initial values for the Transport Property Domains registry are given below; future assignments are to be made by an RFC or with IESG approval for IETF protocol names, on a first come first served basis otherwise.
+
+ | Name      | Description                   | Reference                      |
+ |----------------------------------------------------------------------------|
+ | X         | Experimental and Private use  | this RFC, {{transport-properties}} |
+ | TCP       | TCP specific Properties       | this RFC, {{connection-props}} |
+
+
+## Generic Transport Properties {#generic-properties}
+
+This registry contains the names of well-known Generic Transport Properties as defined in {{transport-properties}}.
+Names are CamelCased strings. 
+Type is one of "Boolean", "Integer", "Numeric", "Enumeration", or "Preference".
+Scope is one of "Pre-Connection", "Connection" or "Message"
+The reference field must point to a document where the usage of the respective property is defined.
+
+Initial values for the Generic Transport Property registry are given below; future assignments are to be made by an RFC or with IESG approval.
+
+ | Name                        | Type     | Scope        | Reference          |
+ |----------------------------------------------------------------------------|
+ | TODO!                       |          |              |                    |
+
+## TCP Specific Properties {#iana-tcp-properties}
+
+This registry contains the well-known Transport Properties specific to TCP.
+The fields are defined analogous to these in the Well-Known Generic Transport Property registry, see {{generic-properties}}.
+
+Initial values for the Well-Known Generic Transport Property registry are given below; future assignments are to be made by an RFC or with IESG approval.
+
+ | Name                        | Type     | Scope        | Reference          |
+ |----------------------------------------------------------------------------|
+ | TODO!                       |          |              |                    |
+
 
 
 # Security Considerations


### PR DESCRIPTION
This PR contains a rough skeleton for an IANA registry fro property names.

It is mainly a proposal and starting point and will be discussed on the Jan'19 Interim.