### PR TITLE
Closes #207. Added "preservation of message boundaries" selection property; turned…

### DIFF
--- a/draft-ietf-taps-interface.md
+++ b/draft-ietf-taps-interface.md
@@ -1644,7 +1644,7 @@ are cloned.
 
 This property specifies how long to wait before deciding that a Connection has
 failed when trying to reliably deliver data to the destination. Adjusting this Property
-is only take effect when the underlying stack supports reliability.
+will only take effect when the underlying stack supports reliability.
 
 
 ### Connection group transmission scheduler {#conn-scheduler}

--- a/draft-ietf-taps-interface.md
+++ b/draft-ietf-taps-interface.md
@@ -503,21 +503,27 @@ implemented over UDP.
 This property specifies whether the application needs to use a transport
 protocol that ensures that all data is received on the other side without
 corruption. This also entails being notified when a Connection is closed or
-aborted. The recommended default is to enable Reliable Data Transfer.
+aborted. The recommended default is to Require Reliable Data Transfer.
+
+### Preservation of Message Boundaries {#prop-boundaries}
+
+This property specifies whether the application needs to use a transport
+protocol that preserves message boundaries. The recommended default
+is to Prefer Preservation of Message Boundaries.
 
 ### Configure per-Message reliability {#prop-partially-reliable}
 
 This property specifies whether an application considers it useful to indicate
 its reliability requirements on a per-Message basis. This property applies to
-Connections and Connection Groups. The recommended default is to not have this
+Connections and Connection Groups. The recommended default is to Prefer this
 option.
 
 ### Preservation of data ordering {#prop-ordering}
 
 This property specifies whether the application wishes to use a transport
 protocol that can ensure that data is received by the application on the other
-end in the same order as it was sent. The recommended default is to preserve
-data ordering.
+end in the same order as it was sent. The recommended default is to Require
+Preservation of data ordering.
 
 ### Use 0-RTT session establishment with an idempotent Message {#prop-0rtt}
 
@@ -525,22 +531,21 @@ This property specifies whether an application would like to supply a Message to
 the transport protocol before Connection establishment, which will then be
 reliably transferred to the other side before or during Connection
 establishment, potentially multiple times. See also {{msg-idempotent}}. The
-recommended default is to not have this option.
+recommended default is to Prefer this option.
 
 ### Multistream Connections in Group {#prop-multistream}
 
 This property specifies that the application would prefer multiple Connections
 within a Connection Group to be provided by streams of a single underlying
-transport connection where possible. The recommended default is to not have
+transport connection where possible. The recommended default is to Prefer have
 this option.
 
 ### Control checksum coverage on sending or receiving {#prop-checksum-control}
 
 This property specifies whether the application considers it useful to enable,
 disable, or configure a checksum when sending a Message, or configure whether to
-require a checksum or not when receiving.  The recommended default is full
-checksum coverage without the option to configure it, and requiring a checksum
-when receiving.
+require a checksum or not when receiving.  The recommended default is to Prefer
+this option for sending, and Require a checksum when receiving.
 
 ### Congestion control {#prop-cc}
 
@@ -550,7 +555,7 @@ controlled, an application using such a Connection should itself perform
 congestion control in accordance with {{?RFC2914}}. Also note that reliability
 is usually combined with congestion control in protocol implementations,
 rendering "reliable but not congestion controlled" a request that is unlikely to
-succeed. The recommended default is that the Connection is congestion
+succeed. The recommended default is to Require that the Connection is congestion
 controlled.
 
 
@@ -560,7 +565,7 @@ This property allows the application to select which specific network interfaces
 or categories of interfaces it wants to `Require`, `Prohibit`, `Prefer`, or
 `Avoid`.
 
-In contrast to other Selection Properties, this property is tuple of an
+In contrast to other Selection Properties, this property is a tuple of an
 (Enumerated) interface identifier and a preference, and can either be
 implemented directly as such, or for making one preference available for each
 interface and interface type available on the system.
@@ -599,7 +604,7 @@ Provisioning Domains or categories of Provisioning Domains it wants to
 consistent sets of network properties that may be more specific than network
 interfaces {{RFC7556}}.
 
-As with interface instances and types, this property is tuple of an (Enumerated)
+As with interface instances and types, this property is a tuple of an (Enumerated)
 PvD identifier and a preference, and can either be implemented directly as such,
 or for making one preference available for each interface and interface type
 available on the system.
@@ -626,16 +631,14 @@ This property specifies whether an application considers it useful to
 transfer data across multiple paths between the same end hosts. Generally,
 in most cases, this will improve performance (e.g., achieve greater throughput).
 One possible side-effect is increased jitter, which may be problematic for
-delay-sensitive applications.
-
-The recommended default is to have this option.
+delay-sensitive applications. The recommended default is to Prefer this option.
 
 
 ### Direction of communication
 
 This property specifies whether an application wants to use the connection for sending and/or receiving data.  Possible values are:
 
-Bidirectional (default):
+Bidirectional (default: Prefer):
 : The connection must support sending and receiving data
 
 Unidirectional send:
@@ -652,7 +655,7 @@ the system should fall back to bidirectional transport.
 
 This property specifies whether an application considers it useful to be
 informed in case sent data was retransmitted more often than a certain
-threshold. The recommended default is to have this option.
+threshold. The recommended default is to Prefer this option.
 
 
 ### Notification of ICMP soft error message arrival {#prop-soft-error}
@@ -662,13 +665,7 @@ informed when an ICMP error message arrives that does not force termination of a
 connection. When set to true, received ICMP errors will be available as
 SoftErrors. Note that even if a protocol supporting this property is selected,
 not all ICMP errors will necessarily be delivered, so applications cannot rely
-on receiving them. The recommended default is not to have this option.
-
-
-### Timeout for aborting Connection Establishment {#prop-establish-timeout}
-
-This property specifies how long to wait before aborting a Connection during establishment.
-
+on receiving them. The recommended default is to Avoid this option.
 
 
 ## Specifying Security Parameters and Callbacks {#security-parameters}
@@ -775,9 +772,10 @@ client-server interactions. Active open is supported by this interface through t
 Initiate Action:
 
 ~~~
-Connection := Preconnection.Initiate()
+Connection := Preconnection.Initiate(timeout)
 ~~~
 
+The timeout parameter specifies how long to wait before aborting Active open.
 Before calling Initiate, the caller must have populated a Preconnection
 Object with a Remote Endpoint specifier, optionally a Local Endpoint
 specifier (if not specified, the system will attempt to determine a
@@ -816,8 +814,8 @@ available Paths and/or Protocol Stacks meeting the constraints is empty) or
 reconciled with the local and/or remote endpoints; when the remote specifier
 cannot be resolved; or when no transport-layer connection can be established to
 the remote endpoint (e.g. because the remote endpoint is not accepting
-connections, or the application is prohibited from opening a Connection by the
-operating system).
+connections, the application is prohibited from opening a Connection by the
+operating system, or the establishment attempt has timed out for any other reason).
 
 See also {{initiate-and-send}} to combine Connection establishment
 and transmission of the first message in a single action.
@@ -1298,13 +1296,13 @@ a first Message sent.
 Without a message context (as in {{send-basic}}):
 
 ~~~
-Connection := Preconnection.InitiateWithSend(messageData)
+Connection := Preconnection.InitiateWithSend(messageData, timeout)
 ~~~
 
 With a message context (as in {{message-props}}):
 
 ~~~
-Connection := Preconnection.InitiateWithSend(messageData, messageContext)
+Connection := Preconnection.InitiateWithSend(messageData, messageContext, timeout)
 ~~~
 
 Whenever possible, a messageContext should be provided to declare the message passed to InitiateWithSend

--- a/draft-ietf-taps-interface.md
+++ b/draft-ietf-taps-interface.md
@@ -291,7 +291,7 @@ Transport Properties can have one of a set of data types:
   property itself. The representation is implementation dependent; however,
   implementations MUST provide a method for the application to determine the
   entire set of possible values for each property.
-- Preference: can take one of five values (Prohibit, Avoid, Ignore, Prefer,
+- Preference: can take one of five values (Prohibit, Avoid, Neutral, Prefer,
   Require) for the level of preference of a given property during protocol
   selection; see {{selection-props}}.
 
@@ -434,7 +434,7 @@ preference levels:
    |------------|------------------------------------------------------------------------|
    | Require    | Select only protocols/paths providing the property, fail otherwise     |
    | Prefer     | Prefer protocols/paths providing the property, proceed otherwise       |
-   | Ignore     | Cancel any system default preference for this property                 |
+   | Neutral    | No preference                                                          |
    | Avoid      | Prefer protocols/paths not providing the property, proceed otherwise   |
    | Prohibit   | Select only protocols/paths not providing the property, fail otherwise |
 
@@ -467,7 +467,7 @@ Selection Properties can be added to a TransportProperties object using special 
 ~~~
 TransportProperties.Require(property)
 TransportProperties.Prefer(property)
-TransportProperties.Ignore(property)
+TransportProperties.Neutral(property)
 TransportProperties.Avoid(property)
 TransportProperties.Prohibit(property)
 ~~~
@@ -488,7 +488,7 @@ Properties are listed in the subsections below. Note that many properties are
 only considered during establishment, and can not be changed after a Connection
 is established; however, they can be queried. Querying a Selection Property
 after establishment yields the value Required for properties of the selected
-protocol and path, Avoid for properties avoided during selection, and Ignore for
+protocol and path, Avoid for properties avoided during selection, and Neutral for
 all other properties.
 
 An implementation of this interface must provide sensible defaults for Selection
@@ -515,8 +515,8 @@ is to Prefer Preservation of Message Boundaries.
 
 This property specifies whether an application considers it useful to indicate
 its reliability requirements on a per-Message basis. This property applies to
-Connections and Connection Groups. The recommended default is to Prefer this
-option.
+Connections and Connection Groups. The recommended default is to be Neutral about
+this option.
 
 ### Preservation of data ordering {#prop-ordering}
 
@@ -544,13 +544,13 @@ this option.
 
 This property specifies whether the application considers it useful to enable,
 disable, or configure a checksum when sending a Message.  The recommended default
-is to Prefer this option.
+is to be Neutral about this option.
 
 ### Control checksum coverage on receiving {#prop-checksum-control-receive}
 
 This property specifies whether the application considers it useful configure whether to
-require a checksum or not when receiving.  The recommended default is to Prefer this
-option.
+require a checksum or not when receiving.  The recommended default is to be Neutral about
+this option.
 
 ### Congestion control {#prop-cc}
 
@@ -643,7 +643,7 @@ delay-sensitive applications. The recommended default is to Prefer this option.
 
 This property specifies whether an application wants to use the connection for sending and/or receiving data.  Possible values are:
 
-Bidirectional (default: Prefer):
+Bidirectional (default):
 : The connection must support sending and receiving data
 
 Unidirectional send:
@@ -777,7 +777,7 @@ client-server interactions. Active open is supported by this interface through t
 Initiate Action:
 
 ~~~
-Connection := Preconnection.Initiate(optional: timeout)
+Connection := Preconnection.Initiate(timeout?)
 ~~~
 
 The timeout parameter specifies how long to wait before aborting Active open.
@@ -1301,13 +1301,13 @@ a first Message sent.
 Without a message context (as in {{send-basic}}):
 
 ~~~
-Connection := Preconnection.InitiateWithSend(messageData, optional: timeout)
+Connection := Preconnection.InitiateWithSend(messageData, timeout?)
 ~~~
 
 With a message context (as in {{message-props}}):
 
 ~~~
-Connection := Preconnection.InitiateWithSend(messageData, messageContext, optional: timeout)
+Connection := Preconnection.InitiateWithSend(messageData, messageContext, timeout?)
 ~~~
 
 Whenever possible, a messageContext should be provided to declare the message passed to InitiateWithSend

--- a/draft-ietf-taps-interface.md
+++ b/draft-ietf-taps-interface.md
@@ -507,7 +507,7 @@ aborted. The recommended default is to Require Reliable Data Transfer.
 
 ### Preservation of Message Boundaries {#prop-boundaries}
 
-This property specifies whether the application needs to use a transport
+This property specifies whether the application needs or prefers to use a transport
 protocol that preserves message boundaries. The recommended default
 is to Prefer Preservation of Message Boundaries.
 
@@ -540,12 +540,17 @@ within a Connection Group to be provided by streams of a single underlying
 transport connection where possible. The recommended default is to Prefer have
 this option.
 
-### Control checksum coverage on sending or receiving {#prop-checksum-control}
+### Control checksum coverage on sending {#prop-checksum-control-send}
 
 This property specifies whether the application considers it useful to enable,
-disable, or configure a checksum when sending a Message, or configure whether to
-require a checksum or not when receiving.  The recommended default is to Prefer
-this option for sending, and Require a checksum when receiving.
+disable, or configure a checksum when sending a Message.  The recommended default
+is to Prefer this option.
+
+### Control checksum coverage on receiving {#prop-checksum-control-receive}
+
+This property specifies whether the application considers it useful configure whether to
+require a checksum or not when receiving.  The recommended default is to Prefer this
+option.
 
 ### Congestion control {#prop-cc}
 
@@ -772,7 +777,7 @@ client-server interactions. Active open is supported by this interface through t
 Initiate Action:
 
 ~~~
-Connection := Preconnection.Initiate(timeout)
+Connection := Preconnection.Initiate(optional: timeout)
 ~~~
 
 The timeout parameter specifies how long to wait before aborting Active open.
@@ -1296,13 +1301,13 @@ a first Message sent.
 Without a message context (as in {{send-basic}}):
 
 ~~~
-Connection := Preconnection.InitiateWithSend(messageData, timeout)
+Connection := Preconnection.InitiateWithSend(messageData, optional: timeout)
 ~~~
 
 With a message context (as in {{message-props}}):
 
 ~~~
-Connection := Preconnection.InitiateWithSend(messageData, messageContext, timeout)
+Connection := Preconnection.InitiateWithSend(messageData, messageContext, optional: timeout)
 ~~~
 
 Whenever possible, a messageContext should be provided to declare the message passed to InitiateWithSend
@@ -1638,7 +1643,9 @@ are cloned.
 ### Timeout for aborting Connection {#conn-timeout}
 
 This property specifies how long to wait before deciding that a Connection has
-failed after establishment.
+failed when trying to reliably deliver data to the destination. Adjusting this Property
+is only take effect when the underlying stack supports reliability.
+
 
 ### Connection group transmission scheduler {#conn-scheduler}
 

--- a/draft-ietf-taps-interface.md
+++ b/draft-ietf-taps-interface.md
@@ -661,7 +661,7 @@ the system should fall back to bidirectional transport.
 
 This property specifies whether an application considers it useful to be
 informed in case sent data was retransmitted more often than a certain
-threshold. The recommended default is to Prefer this option.
+threshold. The recommended default is to Ignore this option.
 
 
 ### Notification of ICMP soft error message arrival {#prop-soft-error}
@@ -671,7 +671,7 @@ informed when an ICMP error message arrives that does not force termination of a
 connection. When set to true, received ICMP errors will be available as
 SoftErrors. Note that even if a protocol supporting this property is selected,
 not all ICMP errors will necessarily be delivered, so applications cannot rely
-on receiving them. The recommended default is to Avoid this option.
+on receiving them. The recommended default is to Ignore this option.
 
 
 ## Specifying Security Parameters and Callbacks {#security-parameters}

--- a/draft-ietf-taps-interface.md
+++ b/draft-ietf-taps-interface.md
@@ -291,7 +291,7 @@ Transport Properties can have one of a set of data types:
   property itself. The representation is implementation dependent; however,
   implementations MUST provide a method for the application to determine the
   entire set of possible values for each property.
-- Preference: can take one of five values (Prohibit, Avoid, Neutral, Prefer,
+- Preference: can take one of five values (Prohibit, Avoid, Ignore, Prefer,
   Require) for the level of preference of a given property during protocol
   selection; see {{selection-props}}.
 
@@ -434,7 +434,7 @@ preference levels:
    |------------|------------------------------------------------------------------------|
    | Require    | Select only protocols/paths providing the property, fail otherwise     |
    | Prefer     | Prefer protocols/paths providing the property, proceed otherwise       |
-   | Neutral    | No preference                                                          |
+   | Ignore    | No preference                                                          |
    | Avoid      | Prefer protocols/paths not providing the property, proceed otherwise   |
    | Prohibit   | Select only protocols/paths not providing the property, fail otherwise |
 
@@ -467,7 +467,7 @@ Selection Properties can be added to a TransportProperties object using special 
 ~~~
 TransportProperties.Require(property)
 TransportProperties.Prefer(property)
-TransportProperties.Neutral(property)
+TransportProperties.Ignore(property)
 TransportProperties.Avoid(property)
 TransportProperties.Prohibit(property)
 ~~~
@@ -488,7 +488,7 @@ Properties are listed in the subsections below. Note that many properties are
 only considered during establishment, and can not be changed after a Connection
 is established; however, they can be queried. Querying a Selection Property
 after establishment yields the value Required for properties of the selected
-protocol and path, Avoid for properties avoided during selection, and Neutral for
+protocol and path, Avoid for properties avoided during selection, and Ignore for
 all other properties.
 
 An implementation of this interface must provide sensible defaults for Selection
@@ -515,7 +515,7 @@ is to Prefer Preservation of Message Boundaries.
 
 This property specifies whether an application considers it useful to indicate
 its reliability requirements on a per-Message basis. This property applies to
-Connections and Connection Groups. The recommended default is to be Neutral about
+Connections and Connection Groups. The recommended default is to Ignore
 this option.
 
 ### Preservation of data ordering {#prop-ordering}
@@ -544,12 +544,12 @@ this option.
 
 This property specifies whether the application considers it useful to enable,
 disable, or configure a checksum when sending a Message.  The recommended default
-is to be Neutral about this option.
+is to Ignore this option.
 
 ### Control checksum coverage on receiving {#prop-checksum-control-receive}
 
 This property specifies whether the application considers it useful configure whether to
-require a checksum or not when receiving.  The recommended default is to be Neutral about
+require a checksum or not when receiving.  The recommended default is to Ignore
 this option.
 
 ### Congestion control {#prop-cc}


### PR DESCRIPTION
… establishment timeout into a parameter of init calls (it stood out strangely in the list of selection properties because it really isn't one); updated defaults for selection properties.